### PR TITLE
Remove julia-0.4 from Travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - 0.6
 notifications:


### PR DESCRIPTION
This updates the Travis build config to reflect that Julia 0.4 support was dropped in 12ef7eb.